### PR TITLE
Allow `ember test --filter` to perform mocha `grep`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,24 @@ var fs = require('fs');
 module.exports = {
   name: 'Ember CLI Mocha',
 
+  overrideTestCommandFilter: function() {
+    var TestCommand = this.project.require('ember-cli/lib/commands/test');
+
+    TestCommand.prototype.buildTestPageQueryString = function(options) {
+      var queryString = '';
+
+      if (options.filter) {
+        queryString = "?grep=" + options.filter;
+      }
+
+      return queryString;
+    };
+  },
+
+  init: function() {
+    this.overrideTestCommandFilter();
+  },
+
   blueprintsPath: function() {
     return path.join(__dirname, 'blueprints');
   },


### PR DESCRIPTION
Enabled by https://github.com/ember-cli/ember-cli/pull/2820.  This will start functioning properly in ember-cli 0.1.5 (where that PR will land in a release), but in the meantime is benign (the function added is unused).

Fixes https://github.com/switchfly/ember-cli-mocha/issues/17.

References:

http://mochajs.org/#grep-option
http://mochajs.org/#grep-query
