### PR TITLE
Check before outputting needs in model-test

### DIFF
--- a/blueprints/model-test/files/tests/unit/models/__test__.js
+++ b/blueprints/model-test/files/tests/unit/models/__test__.js
@@ -9,7 +9,7 @@ describeModel(
   '<%= classifiedModuleName %>',
   {
     // Specify the other units that are required for this test.
-    <%= needs %>
+    <%= typeof needs !== 'undefined' ? needs : '' %>
   },
   function() {
     // Replace this with your real tests.


### PR DESCRIPTION
I submitted a similar pull request at ember-cli/ember-cli#2829. Coïncidentally I came across this in my own `ember-cli-mocha`-using application just now when generating a standalone test to [answer this StackOverflow question](https://stackoverflow.com/questions/27629728/how-can-i-unit-test-class-methods-in-ember-cli), so I figured I’d suggest it here too.

This is helpful for a model test generated by itself rather than at the same time as a model, because the lack of a `needs` in the locals passed in to the blueprint template results in the none of the template variables being substituted and consequently invalid Javascript, as shown [here](https://github.com/ember-cli/ember-cli/issues/2755#issuecomment-67851810) by @karlrl.

Perhaps you have an automated way to convert the QUnit blueprints and this is unnecessary, close away if so.

I didn’t see any tests to add to, but it’s the same change that passed the tests on `ember-cli`, and I confirmed that it worked in my own application.
