### PR TITLE
[WIP] Update blueprints to take advantage of implicit `Ember.run` in beforeEach/afterEach

### DIFF
--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
@@ -17,14 +17,14 @@ describe('Acceptance: <%= classifiedModuleName %>', function() {
   });
 
   afterEach(function() {
-    Ember.run(application, 'destroy');
+    application.destroy();
+  });
+
+  beforeEach(function() {
+    visit('/<%= dasherizedModuleName %>');
   });
 
   it('can visit /<%= dasherizedModuleName %>', function() {
-    visit('/<%= dasherizedModuleName %>');
-
-    andThen(function() {
-      expect(currentPath()).to.equal('<%= dasherizedModuleName %>');
-    });
+    expect(currentPath()).to.equal('<%= dasherizedModuleName %>');
   });
 });

--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
@@ -10,14 +10,12 @@ import Ember from 'ember';
 import startApp from '../helpers/start-app';
 
 describe('Acceptance: <%= classifiedModuleName %>', function() {
-  var application;
-
   beforeEach(function() {
-    application = startApp();
+    this.application = startApp();
   });
 
   afterEach(function() {
-    application.destroy();
+    this.application.destroy();
   });
 
   beforeEach(function() {

--- a/blueprints/ember-cli-mocha/index.js
+++ b/blueprints/ember-cli-mocha/index.js
@@ -13,7 +13,7 @@ module.exports = {
     var addonContext = this;
 
     return this.addBowerPackagesToProject([
-      { name: 'ember-mocha',           source: 'ember-mocha',                     target: '~0.8.0' },
+      { name: 'ember-mocha',           source: 'ember-mocha',                     target: '~0.8.3' },
       { name: 'ember-cli-test-loader', source: 'ember-cli/ember-cli-test-loader', target: '0.1.3'  },
       { name: 'ember-cli-shims',       source: 'ember-cli/ember-cli-shims',       target: '0.0.3'  }
     ]).then(function() {


### PR DESCRIPTION
As of ember-mocha v0.8.3, `beforeEach` and `afterEach` now happen in the context of an `Ember.run`, and so this takes advantage of that.

This also changes the `visit` invocation to happen in its own `beforeEach` to move it in line with the convention that side-effcts happen in beforeEach blocks, and assertions in `it` blocks. (I find that I very rarely use `andThen`)

If this looks good, I can change the other test blueprints.
