### PR TITLE
avoid writing jshint ignore in blueprint tests if jshint is not detected

### DIFF
--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
@@ -1,5 +1,5 @@
-/* jshint expr:true */
-import {
+<% if (jshintExists) { %>/* jshint expr:true */
+<% } %>import {
   describe,
   it,
   beforeEach,

--- a/blueprints/acceptance-test/index.js
+++ b/blueprints/acceptance-test/index.js
@@ -8,8 +8,12 @@ module.exports = {
     var destroyAppExists =
       existsSync(path.join(this.project.root, '/tests/helpers/destroy-app.js'));
 
+    var packages = Object.keys(this.project.addonPackages);
+    var jshintExists = packages.indexOf('ember-cli-jshint') !== -1;
+
     return {
-      destroyAppExists: destroyAppExists
+      destroyAppExists: destroyAppExists,
+      jshintExists: jshintExists
     };
   }
 };

--- a/blueprints/adapter-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/adapter-test/files/tests/unit/__path__/__test__.js
@@ -1,5 +1,5 @@
-/* jshint expr:true */
-import { expect } from 'chai';
+<% if (jshintExists) { %>/* jshint expr:true */
+<% } %>import { expect } from 'chai';
 import {
   describeModule,
   it

--- a/blueprints/adapter-test/index.js
+++ b/blueprints/adapter-test/index.js
@@ -1,3 +1,12 @@
 module.exports = {
-  description: 'Generates an ember-data adapter unit test'
+  description: 'Generates an ember-data adapter unit test',
+
+  locals: function() {
+    var packages = Object.keys(this.project.addonPackages);
+    var jshintExists = packages.indexOf('ember-cli-jshint') !== -1;
+
+    return {
+      jshintExists: jshintExists
+    };
+  }
 };

--- a/blueprints/component-test/files/tests/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/files/tests/__testType__/__path__/__test__.js
@@ -1,5 +1,5 @@
-/* jshint expr:true */
-import { expect } from 'chai';
+<% if (jshintExists) { %>/* jshint expr:true */
+<% } %>import { expect } from 'chai';
 import {
   describeComponent,
   it

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -19,9 +19,12 @@ module.exports = {
 
   locals: function(options) {
     var testType = options.testType || "integration";
+    var packages = Object.keys(this.project.addonPackages);
+    var jshintExists = packages.indexOf('ember-cli-jshint') !== -1;
 
     return {
-      testType: testType
+      testType: testType,
+      jshintExists: jshintExists
     };
   },
 

--- a/blueprints/controller-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/controller-test/files/tests/unit/__path__/__test__.js
@@ -1,5 +1,5 @@
-/* jshint expr:true */
-import { expect } from 'chai';
+<% if (jshintExists) { %>/* jshint expr:true */
+<% } %>import { expect } from 'chai';
 import {
   describeModule,
   it

--- a/blueprints/controller-test/index.js
+++ b/blueprints/controller-test/index.js
@@ -1,3 +1,12 @@
 module.exports = {
-  description: 'Generates a controller unit test.'
+  description: 'Generates a controller unit test.',
+
+  locals: function() {
+    var packages = Object.keys(this.project.addonPackages);
+    var jshintExists = packages.indexOf('ember-cli-jshint') !== -1;
+
+    return {
+      jshintExists: jshintExists
+    };
+  }
 };

--- a/blueprints/helper-test/files/tests/unit/helpers/__name__-test.js
+++ b/blueprints/helper-test/files/tests/unit/helpers/__name__-test.js
@@ -1,5 +1,5 @@
-/* jshint expr:true */
-import { expect } from 'chai';
+<% if (jshintExists) { %>/* jshint expr:true */
+<% } %>import { expect } from 'chai';
 import {
   describe,
   it

--- a/blueprints/helper-test/index.js
+++ b/blueprints/helper-test/index.js
@@ -1,3 +1,12 @@
 module.exports = {
-  description: 'Generates a helper unit test.'
+  description: 'Generates a helper unit test.',
+
+  locals: function() {
+    var packages = Object.keys(this.project.addonPackages);
+    var jshintExists = packages.indexOf('ember-cli-jshint') !== -1;
+
+    return {
+      jshintExists: jshintExists
+    };
+  }
 };

--- a/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
@@ -1,5 +1,5 @@
-/* jshint expr:true */
-import { expect } from 'chai';
+<% if (jshintExists) { %>/* jshint expr:true */
+<% } %>import { expect } from 'chai';
 import {
   describe,
   it,

--- a/blueprints/initializer-test/index.js
+++ b/blueprints/initializer-test/index.js
@@ -1,3 +1,12 @@
 module.exports = {
-  description: 'Generates an initializer unit test.'
+  description: 'Generates an initializer unit test.',
+
+  locals: function() {
+    var packages = Object.keys(this.project.addonPackages);
+    var jshintExists = packages.indexOf('ember-cli-jshint') !== -1;
+
+    return {
+      jshintExists: jshintExists
+    };
+  }
 };

--- a/blueprints/instance-initializer-test/files/tests/unit/instance-initializers/__name__-test.js
+++ b/blueprints/instance-initializer-test/files/tests/unit/instance-initializers/__name__-test.js
@@ -1,5 +1,5 @@
-/* jshint expr:true */
-import { expect } from 'chai';
+<% if (jshintExists) { %>/* jshint expr:true */
+<% } %>import { expect } from 'chai';
 import {
   describe,
   it,

--- a/blueprints/instance-initializer-test/index.js
+++ b/blueprints/instance-initializer-test/index.js
@@ -4,9 +4,12 @@ module.exports = {
   locals: function() {
     var destroyAppExists =
       existsSync(path.join(this.project.root, '/tests/helpers/destroy-app.js'));
+    var packages = Object.keys(this.project.addonPackages);
+    var jshintExists = packages.indexOf('ember-cli-jshint') !== -1;
 
     return {
-      destroyAppExists: destroyAppExists
+      destroyAppExists: destroyAppExists,
+      jshintExists: jshintExists
     };
   }
 };

--- a/blueprints/mixin-test/files/tests/unit/mixins/__name__-test.js
+++ b/blueprints/mixin-test/files/tests/unit/mixins/__name__-test.js
@@ -1,5 +1,5 @@
-/* jshint expr:true */
-import { expect } from 'chai';
+<% if (jshintExists) { %>/* jshint expr:true */
+<% } %>import { expect } from 'chai';
 import {
   describe,
   it

--- a/blueprints/mixin-test/index.js
+++ b/blueprints/mixin-test/index.js
@@ -1,3 +1,12 @@
 module.exports = {
-  description: 'Generates a mixin unit test.'
+  description: 'Generates a mixin unit test.',
+
+  locals: function() {
+    var packages = Object.keys(this.project.addonPackages);
+    var jshintExists = packages.indexOf('ember-cli-jshint') !== -1;
+
+    return {
+      jshintExists: jshintExists
+    };
+  }
 };

--- a/blueprints/model-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/model-test/files/tests/unit/__path__/__test__.js
@@ -1,5 +1,5 @@
-/* jshint expr:true */
-import { expect } from 'chai';
+<% if (jshintExists) { %>/* jshint expr:true */
+<% } %>import { expect } from 'chai';
 import {
   describeModel,
   it

--- a/blueprints/model-test/index.js
+++ b/blueprints/model-test/index.js
@@ -1,3 +1,12 @@
 module.exports = {
-  description: 'Generates a model unit test.'
+  description: 'Generates a model unit test.',
+
+  locals: function() {
+    var packages = Object.keys(this.project.addonPackages);
+    var jshintExists = packages.indexOf('ember-cli-jshint') !== -1;
+
+    return {
+      jshintExists: jshintExists
+    };
+  }
 };

--- a/blueprints/route-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/route-test/files/tests/unit/__path__/__test__.js
@@ -1,5 +1,5 @@
-/* jshint expr:true */
-import { expect } from 'chai';
+<% if (jshintExists) { %>/* jshint expr:true */
+<% } %>import { expect } from 'chai';
 import {
   describeModule,
   it

--- a/blueprints/route-test/index.js
+++ b/blueprints/route-test/index.js
@@ -1,3 +1,12 @@
 module.exports = {
-  description: 'Generates a route unit test.'
+  description: 'Generates a route unit test.',
+
+  locals: function() {
+    var packages = Object.keys(this.project.addonPackages);
+    var jshintExists = packages.indexOf('ember-cli-jshint') !== -1;
+
+    return {
+      jshintExists: jshintExists
+    };
+  }
 };

--- a/blueprints/serializer-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/serializer-test/files/tests/unit/__path__/__test__.js
@@ -1,5 +1,5 @@
-/* jshint expr:true */
-import { expect } from 'chai';
+<% if (jshintExists) { %>/* jshint expr:true */
+<% } %>import { expect } from 'chai';
 import {
   describeModule,
   it

--- a/blueprints/serializer-test/index.js
+++ b/blueprints/serializer-test/index.js
@@ -1,3 +1,12 @@
 module.exports = {
-  description: 'Generates a serializer unit test.'
+  description: 'Generates a serializer unit test.',
+
+  locals: function() {
+    var packages = Object.keys(this.project.addonPackages);
+    var jshintExists = packages.indexOf('ember-cli-jshint') !== -1;
+
+    return {
+      jshintExists: jshintExists
+    };
+  }
 };

--- a/blueprints/service-test/files/tests/unit/services/__name__-test.js
+++ b/blueprints/service-test/files/tests/unit/services/__name__-test.js
@@ -1,5 +1,5 @@
-/* jshint expr:true */
-import { expect } from 'chai';
+<% if (jshintExists) { %>/* jshint expr:true */
+<% } %>import { expect } from 'chai';
 import {
   describeModule,
   it

--- a/blueprints/service-test/index.js
+++ b/blueprints/service-test/index.js
@@ -1,3 +1,12 @@
 module.exports = {
-  description: 'Generates a service unit test.'
+  description: 'Generates a service unit test.',
+
+  locals: function() {
+    var packages = Object.keys(this.project.addonPackages);
+    var jshintExists = packages.indexOf('ember-cli-jshint') !== -1;
+
+    return {
+      jshintExists: jshintExists
+    };
+  }
 };

--- a/blueprints/transform-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/transform-test/files/tests/unit/__path__/__test__.js
@@ -1,5 +1,5 @@
-/* jshint expr:true */
-import { expect } from 'chai';
+<% if (jshintExists) { %>/* jshint expr:true */
+<% } %>import { expect } from 'chai';
 import {
   describeModule,
   it

--- a/blueprints/transform-test/index.js
+++ b/blueprints/transform-test/index.js
@@ -1,3 +1,12 @@
 module.exports = {
-  description: 'Generates a transform unit test.'
+  description: 'Generates a transform unit test.',
+
+  locals: function() {
+    var packages = Object.keys(this.project.addonPackages);
+    var jshintExists = packages.indexOf('ember-cli-jshint') !== -1;
+
+    return {
+      jshintExists: jshintExists
+    };
+  }
 };

--- a/blueprints/util-test/files/tests/unit/utils/__name__-test.js
+++ b/blueprints/util-test/files/tests/unit/utils/__name__-test.js
@@ -1,5 +1,5 @@
-/* jshint expr:true */
-import { expect } from 'chai';
+<% if (jshintExists) { %>/* jshint expr:true */
+<% } %>import { expect } from 'chai';
 import {
   describe,
   it

--- a/blueprints/util-test/index.js
+++ b/blueprints/util-test/index.js
@@ -1,3 +1,12 @@
 module.exports = {
-  description: 'Generates a util unit test.'
+  description: 'Generates a util unit test.',
+
+  locals: function() {
+    var packages = Object.keys(this.project.addonPackages);
+    var jshintExists = packages.indexOf('ember-cli-jshint') !== -1;
+
+    return {
+      jshintExists: jshintExists
+    };
+  }
 };

--- a/blueprints/view-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/view-test/files/tests/unit/__path__/__test__.js
@@ -1,5 +1,5 @@
-/* jshint expr:true */
-import { expect } from 'chai';
+<% if (jshintExists) { %>/* jshint expr:true */
+<% } %>import { expect } from 'chai';
 import {
   describeModule,
   it

--- a/blueprints/view-test/index.js
+++ b/blueprints/view-test/index.js
@@ -1,3 +1,12 @@
 module.exports = {
-  description: 'Generates a view unit test.'
+  description: 'Generates a view unit test.',
+
+  locals: function() {
+    var packages = Object.keys(this.project.addonPackages);
+    var jshintExists = packages.indexOf('ember-cli-jshint') !== -1;
+
+    return {
+      jshintExists: jshintExists
+    };
+  }
 };


### PR DESCRIPTION
Addresses #117.

This will only output the following line if `ember-cli-jshint` is detected in the project's add on packages.
```
/* jshint expr:true */
```
