### PR TITLE
Remove `ember-cli-test-loader` bower dependency

### DIFF
--- a/blueprints/ember-cli-mocha/index.js
+++ b/blueprints/ember-cli-mocha/index.js
@@ -14,7 +14,6 @@ module.exports = {
 
     return this.addBowerPackagesToProject([
       { name: 'ember-mocha-adapter',   source: 'ember-mocha-adapter',   target: '~0.3.1' },
-      { name: 'ember-cli-test-loader', source: 'ember-cli-test-loader', target: '0.2.2'  }
     ]).then(function() {
       if ('removePackageFromProject' in addonContext) {
         return addonContext.removePackageFromProject('ember-cli-qunit');

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "broccoli-merge-trees": "^1.1.1",
     "chai": "^3.5.0",
     "ember-cli-babel": "^5.1.6",
+    "ember-cli-test-loader": "^1.1.0",
     "ember-cli-version-checker": "^1.1.6",
     "ember-mocha": "^0.8.11",
     "exists-sync": "0.0.3",


### PR DESCRIPTION
I tried this with a demo app, by
- generating a new Ember app
- Installing `ember-cli-mocha` (this branch)
- Removing the `ember-cli-test-loader` from the `package.json` and reinstalling all the dependencies, so that the test loader _must_ have come from the `shouldIncludeChildAddon` hook
- Ran `ember test` in the demo addon

Everything works as you'd expect.

I did run into the problem that the tests for this repo are not passing after this change.  For some reason, [`requiredModules`](https://github.com/switchfly/ember-cli-mocha/blob/7023a94bf35e26dd2826ff4e7d227f99bbec54d0/tests/unit/test-loader-test.js#L40) doesn't include `valid.jshint`.  Any idea why that might be?

Closes #122 
