### PR TITLE
Let mocha float from 2.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "ember-cli-version-checker": "^1.1.6",
     "ember-mocha": "^0.8.11",
     "exists-sync": "0.0.3",
-    "mocha": "^2.5.3",
+    "mocha": "^2.4.5",
     "resolve": "^1.1.7"
   }
 }


### PR DESCRIPTION
As part of the change in #124 to stop loading mocha from bower the version of mocha was changed from `~2.4.5` to `^2.5.3`.  For reasons that are not immediately obvious to me due to lack of time to dig in this breaks the test suite in one of our apps because mocha is not respecting `.skip` flags.

I would still like to be able to use the latest changes in ember-cli-mocha though, so this PR changes the version of mocha specified in ember-cli-mocha to `^2.4.5`.  By default this will still give consumers of ember-cli-mocha  version `2.5.3` of mocha, but it allows consumers of ember-cli-mocha to specify in their package.json version `2.4.5` to avoid any possible side effects of the bower -> npm change in this addon.

