### PR TITLE
Fix broken test-loader test

### DIFF
--- a/tests/unit/test-loader-test.js
+++ b/tests/unit/test-loader-test.js
@@ -17,7 +17,7 @@ describe('Unit | test-loader', function() {
     window.requirejs.entries = {
       'valid-test': true,
       'valid_test': true,
-      'valid.jshint': true,
+      'valid.jshint.lint-test': true,
       'not-valid-jshint': true,
       'not-a-test-module': true,
       'nohyphentest': true
@@ -34,7 +34,7 @@ describe('Unit | test-loader', function() {
     var expectedModules = [
       'valid-test',
       'valid_test',
-      'valid.jshint'
+      'valid.jshint.lint-test'
     ];
 
     expect(requiredModules).to.deep.equal(expectedModules);


### PR DESCRIPTION
The new "ember-cli-test-loader" version isn't loading modules ending in ".jshint" anymore, which is not an issue though since "ember-cli-jshint" is generating files ending in ".jshint.lint-test" now.

This test was seemingly broken by #129 and wasn't caught because TravisCI was not running anymore after we moved the repository to the `ember-cli` org.

/cc @alexlafroscia 