### PR TITLE
Add "ember-cli-chai" to project instead of making it a dependency

### DIFF
--- a/blueprints/ember-cli-mocha/index.js
+++ b/blueprints/ember-cli-mocha/index.js
@@ -14,7 +14,11 @@ module.exports = {
 
     return this.addBowerPackagesToProject([
       { name: 'ember-mocha-adapter',   source: 'ember-mocha-adapter',   target: '~0.3.1' },
+
     ]).then(function() {
+      return addonContext.addPackageToProject('ember-cli-chai', '^0.2.0');
+
+    }).then(function() {
       if ('removePackageFromProject' in addonContext) {
         return addonContext.removePackageFromProject('ember-cli-qunit');
       }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.1",
     "ember-cli-babel": "^5.1.7",
-    "ember-cli-chai": "^0.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-version-checker": "^1.1.6",
     "ember-mocha": "^0.9.1",
@@ -43,6 +42,7 @@
   },
   "devDependencies": {
     "ember-cli": "2.9.1",
+    "ember-cli-chai": "^0.2.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars": "^1.0.10",
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",


### PR DESCRIPTION
This lets users use different versions of "ember-cli-chai" if they choose to do so (e.g. chai 3.5.x vs. chai 4.x)

The PR also update `ember-cli-chai` to v0.2.0

This is a **breaking change**. Users of `ember-cli-mocha` will have to add `ember-cli-chai` to their `package.json` file to keep things working.

see https://github.com/ember-cli/ember-cli-mocha/pull/143#issuecomment-262994134