### PR TITLE
blueprints: Update auto-installed "ember-cli-chai" to v0.3.0

### DIFF
--- a/blueprints/ember-cli-mocha/index.js
+++ b/blueprints/ember-cli-mocha/index.js
@@ -16,7 +16,7 @@ module.exports = {
       { name: 'ember-mocha-adapter',   source: 'ember-mocha-adapter',   target: '~0.3.1' },
 
     ]).then(function() {
-      return addonContext.addPackageToProject('ember-cli-chai', '^0.2.0');
+      return addonContext.addPackageToProject('ember-cli-chai', '^0.3.0');
 
     }).then(function() {
       if ('removePackageFromProject' in addonContext) {


### PR DESCRIPTION
This follows the discussion in https://github.com/ember-cli/ember-cli-mocha/issues/154