### PR TITLE
Add Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ember-cli-mocha
 
+[![Build Status](https://travis-ci.org/ember-cli/ember-cli-mocha.svg?branch=master)](https://travis-ci.org/ember-cli/ember-cli-mocha)
+
 Mocha / Chai testing for your Ember CLI apps.
 
 ## Installation


### PR DESCRIPTION
Addon is missing the 10 points on emberobserver.com probably because of this (says it has no build). 😉