### PR TITLE
Prevent clobbering custom `this.options.babel`

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,8 +156,6 @@ module.exports = {
     var target = (parentAddon || app);
     this._super.included.call(this, target);
 
-    this.options = target.options || {};
-
     if (app.tests) {
       var fileAssets = [
         'vendor/mocha/mocha.js',


### PR DESCRIPTION
Setting `this.options` inside of `included` to the options from `lib/broccoli/ember-app` means that we will attempt to transpile with the `options.babel` that the host app / addon is using. Which, as of, 2.13+ that will be babel@6 and therefore incompatible options with ember-cli-babel@5 (which this addon uses).

Resolves https://github.com/ember-cli/ember-cli-mocha/issues/182