### PR TITLE
Remove dependency to jquery

### DIFF
--- a/vendor/ember-cli-mocha/test-loader.js
+++ b/vendor/ember-cli-mocha/test-loader.js
@@ -1,31 +1,35 @@
-/* globals jQuery, chai, mocha, require, requirejs */
+/* globals describe, it, mocha, require, requirejs */
 
-jQuery(document).ready(function() {
-  var testLoaderModulePath = 'ember-cli-test-loader/test-support/index';
+document.addEventListener(
+  "DOMContentLoaded",
+  function() {
+    var testLoaderModulePath = "ember-cli-test-loader/test-support/index";
 
-  if (!requirejs.entries[testLoaderModulePath]) {
-    testLoaderModulePath = 'ember-cli/test-loader';
-  }
+    if (!requirejs.entries[testLoaderModulePath]) {
+      testLoaderModulePath = "ember-cli/test-loader";
+    }
 
-  var TestLoader = require(testLoaderModulePath)['default'];
-  TestLoader.prototype.shouldLoadModule = function(moduleName) {
-    return moduleName.match(/[-_]test$/) || moduleName.match(/\.jshint$/);
-  };
+    var TestLoader = require(testLoaderModulePath)["default"];
+    TestLoader.prototype.shouldLoadModule = function(moduleName) {
+      return moduleName.match(/[-_]test$/) || moduleName.match(/\.jshint$/);
+    };
 
-  TestLoader.prototype.moduleLoadFailure = function(moduleName, error) {
-    describe('TestLoader Failures', function () {
-      it(moduleName + ': could not be loaded', function() {
-        throw error;
+    TestLoader.prototype.moduleLoadFailure = function(moduleName, error) {
+      describe("TestLoader Failures", function() {
+        it(moduleName + ": could not be loaded", function() {
+          throw error;
+        });
       });
-    });
-  };
+    };
 
-  // Attempt to mitigate sourcemap issues in Chrome
-  // See: https://github.com/ember-cli/ember-cli/issues/3098
-  //      https://github.com/ember-cli/ember-cli-qunit/pull/39
-  setTimeout(function() {
-    TestLoader.load();
+    // Attempt to mitigate sourcemap issues in Chrome
+    // See: https://github.com/ember-cli/ember-cli/issues/3098
+    //      https://github.com/ember-cli/ember-cli-qunit/pull/39
+    setTimeout(function() {
+      TestLoader.load();
 
-    window.mochaRunner = mocha.run();
-  }, 250);
-});
+      window.mochaRunner = mocha.run();
+    }, 250);
+  },
+  false
+);

--- a/vendor/ember-cli-mocha/test-loader.js
+++ b/vendor/ember-cli-mocha/test-loader.js
@@ -1,22 +1,22 @@
 /* globals describe, it, mocha, require, requirejs */
 
 document.addEventListener(
-  "DOMContentLoaded",
+  'DOMContentLoaded',
   function() {
-    var testLoaderModulePath = "ember-cli-test-loader/test-support/index";
+    var testLoaderModulePath = 'ember-cli-test-loader/test-support/index';
 
     if (!requirejs.entries[testLoaderModulePath]) {
-      testLoaderModulePath = "ember-cli/test-loader";
+      testLoaderModulePath = 'ember-cli/test-loader';
     }
 
-    var TestLoader = require(testLoaderModulePath)["default"];
+    var TestLoader = require(testLoaderModulePath)['default'];
     TestLoader.prototype.shouldLoadModule = function(moduleName) {
       return moduleName.match(/[-_]test$/) || moduleName.match(/\.jshint$/);
     };
 
     TestLoader.prototype.moduleLoadFailure = function(moduleName, error) {
-      describe("TestLoader Failures", function() {
-        it(moduleName + ": could not be loaded", function() {
+      describe('TestLoader Failures', function() {
+        it(moduleName + ': could not be loaded', function() {
           throw error;
         });
       });


### PR DESCRIPTION
This PR will remove the dependency to jQuery which will enable users to test completely without jQuery.

I also altered the eslint globals since some were unused and others missing.

BTW: `DOMContentLoaded` is [supported by IE9+](https://caniuse.com/#feat=domcontentloaded) so compatibility will not be a problem