### PR TITLE
CI: Allow failures for `ember-beta`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:


### PR DESCRIPTION
This is a temporary measure to fix CI builds while `ember-beta` is pointing to Ember 3.x which is no longer distributed via Bower