### PR TITLE
blueprints: Add `start/destroy-app` test helper files

### DIFF
--- a/blueprints/ember-cli-mocha/files/tests/helpers/destroy-app.js
+++ b/blueprints/ember-cli-mocha/files/tests/helpers/destroy-app.js
@@ -1,0 +1,5 @@
+import { run } from '@ember/runloop';
+
+export default function destroyApp(application) {
+  run(application, 'destroy');
+}

--- a/blueprints/ember-cli-mocha/files/tests/helpers/start-app.js
+++ b/blueprints/ember-cli-mocha/files/tests/helpers/start-app.js
@@ -1,0 +1,17 @@
+import Application from '../../app';
+import config from '../../config/environment';
+import { merge } from '@ember/polyfills';
+import { run } from '@ember/runloop';
+
+export default function startApp(attrs) {
+  let attributes = merge({}, config.APP);
+  attributes.autoboot = true;
+  attributes = merge(attributes, attrs); // use defaults, but you can override;
+
+  return run(() => {
+    let application = Application.create(attributes);
+    application.setupForTesting();
+    application.injectTestHelpers();
+    return application;
+  });
+}


### PR DESCRIPTION
These files were removed in https://github.com/ember-cli/ember-cli/pull/7546, but `ember-cli-mocha` (and `ember-mocha`) still need them.

see also https://github.com/ember-cli/ember-cli-mocha/pull/237#issuecomment-359248541

An alternative would be to add them to the `acceptance-test` blueprint in Ember.js itself for the `ember-cli-mocha` case 🤔 