### PR TITLE
CI: Add version constraint to `auto-dist-tag` installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
   - yarn ember try:one $EMBER_TRY_SCENARIO test
 
 before_deploy:
-  - yarn global add auto-dist-tag
+  - yarn global add auto-dist-tag@0.1
   - auto-dist-tag --write
 
 deploy:


### PR DESCRIPTION
This is needed for Node 4 support